### PR TITLE
feat: added TimeloopBreak as a mechanism to break timeloops

### DIFF
--- a/timeloops.go
+++ b/timeloops.go
@@ -1,29 +1,29 @@
 package timeloops
 
 import (
+	"errors"
 	"time"
 )
 
-// Break is a function that will break a the timeloop.
-type Break func()
+// Return TimeloopBreak to break the timeloop.
+//
+//lint:ignore ST1012 Overload the error type for easy API.
+var TimeloopBreak error = errors.New("break")
 
-// TimeLoopFunc is a function that will be executed in a timeloop.
-type TimeloopFunc func(Break)
-
-// ForDuration will perform some action in a loop for a given time.Duration, once
-// the timer expires, or once n loops have been completed this function will
-// return
-func ForDuration(n int, duration time.Duration, fn TimeloopFunc) {
+// ForDuration will perform some action in a loop for a given time.Duration,
+// once the timer expires, or once n loops have been completed this function
+// will return
+func ForDuration(n int, duration time.Duration, fn func() error) error {
 	bf := breakFuncFactory(n)
 	timer := time.NewTimer(duration)
-	executeForNIterationsOrTimeout(n, bf, timer.C, fn)
+	return executeForNIterationsOrTimeout(n, bf, timer.C, fn)
 }
 
 // ForTimer will perform some action in a loop for a given *time.Timer, once
 // the timer expires, or once n loops have been completed this function will
 // return
-func ForTimer(n int, timer *time.Timer, fn TimeloopFunc) {
-	executeForNIterationsOrTimeout(n, breakFuncFactory(n), timer.C, fn)
+func ForTimer(n int, timer *time.Timer, fn func() error) error {
+	return executeForNIterationsOrTimeout(n, breakFuncFactory(n), timer.C, fn)
 }
 
 // breakFuncFactory will generate a function to break the loop
@@ -45,14 +45,10 @@ var executeForNIterationsOrTimeout = func(
 	n int,
 	bfn func(n int) bool,
 	stopChan <-chan time.Time,
-	fn TimeloopFunc,
-) {
-	stop := false
-	brk := func() {
-		stop = true
-	}
+	fn func() error,
+) error {
 Loop:
-	for !stop {
+	for {
 		if bfn(n) {
 			break
 		}
@@ -60,8 +56,14 @@ Loop:
 		case <-stopChan:
 			break Loop
 		default:
-			fn(brk)
+			if err := fn(); err != nil {
+				if errors.Is(err, TimeloopBreak) {
+					break Loop
+				}
+				return err
+			}
 			n--
 		}
 	}
+	return nil
 }

--- a/timeloops_test.go
+++ b/timeloops_test.go
@@ -125,9 +125,12 @@ func TestForDuringChanWithBreakCalled(t *testing.T) {
 		}
 		return nil
 	}
-	executeForNIterationsOrTimeout(3, x, tc, fn)
+	err := executeForNIterationsOrTimeout(3, x, tc, fn)
 
 	if ticks != 3 {
 		t.Fatalf("expected: %d, got: %d", 3, ticks)
+	}
+	if err != nil {
+		t.Fatal("did not expect an error")
 	}
 }

--- a/timeloops_test.go
+++ b/timeloops_test.go
@@ -1,4 +1,4 @@
-package timeloop
+package timeloops
 
 import (
 	"testing"
@@ -8,8 +8,8 @@ import (
 func TestCountDuration(t *testing.T) {
 	count := 5
 	results := 0
-	ForDuration(count, 5*time.Second, func() {
-		results += 1
+	ForDuration(count, 5*time.Second, func(Break) {
+		results++
 	})
 	if results != 5 {
 		t.Fatal("did not reach expected count")
@@ -19,7 +19,7 @@ func TestCountDuration(t *testing.T) {
 func TestCountTimer(t *testing.T) {
 	count := 5
 	results := 0
-	ForTimer(count, time.NewTimer(5*time.Second), func() {
+	ForTimer(count, time.NewTimer(5*time.Second), func(Break) {
 		results += 1
 	})
 	if results != 5 {


### PR DESCRIPTION
# Intent

The intent of this PR is to introduce the ability for users to be able to specify when a Timeloop should be broken. 

In order to do this, we introduce a new `error` type called `TimeloopBreak`, which the `executeForNIterationsOrTimeout` function simply checks for if the user's provided func returns it. 

If it does, then the loop is broken, and the timeloop function called returns a `nil` error. However, as a side effect of this all function signatures must be updated to return an error. 

This ofcourse has the advantage of allowing user's to have error handling in their Timeloop executions, however it additionally introduces more complexity to the supplied API, albeit a small one.
